### PR TITLE
Change msiexec flag to prevent modal dialog

### DIFF
--- a/brigadier
+++ b/brigadier
@@ -114,7 +114,7 @@ def findBootcampMSI(search_dir):
 
 def installBootcamp(msipath):
     logpath = os.path.abspath("/BootCamp_Install.log")
-    cmd = ['cmd', '/c', 'msiexec', '/i', msipath, '/qr', '/norestart', '/log', logpath]
+    cmd = ['cmd', '/c', 'msiexec', '/i', msipath, '/qb-', '/norestart', '/log', logpath]
     status("Executing command: '%s'" % " ".join(cmd))
     subprocess.call(cmd)
     status("Install log output:")


### PR DESCRIPTION
In testing Brigadier with W8.1, we found that the modal created by msiexec was halting execution. Following TechNet's [msiexec docs](https://technet.microsoft.com/en-us/library/cc759262(v=ws.10).aspx#BKMK_SetUI), we found that `/qb-` or another UI level that didn't include a modal dialog would complete successfully. Is there a reason not to use `/qn`?

