### PR TITLE
Add documentation about using `python3` branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Place a `brigadier.plist` file in the same folder as the script to override the 
 
 Additional options shown below.
 
+### Usage on newer Macs
+
+To use it on newer mac machines that come with **Python 3**, use the `python3` branch.
+
 ## Getting it
 
 You can find a pre-compiled binary for Windows in the [releases](https://github.com/timsutton/brigadier/releases) area. This can be useful if you don't already have Python installed on Windows. This was built using [PyInstaller](http://www.pyinstaller.org). More details on building it yourself [below](#runningbuilding-from-source-on-windows).


### PR DESCRIPTION
So I tried using this script on a newer Mac that comes with Python 3 installed as `python3` and had to navigate through several issues in order to realize there's a `python3` branch that works flawlessly (found an answer in #91).

I think it would be nice mentioning it in the projects' Readme.

Let me know if you think it makes sense adding it in other section or anything else.

BTW, thank you for this tool, it really saved my day <3