### PR TITLE
Possible 7z Fix

### DIFF
--- a/brigadier
+++ b/brigadier
@@ -20,7 +20,7 @@ from xml.dom import minidom
 VERSION = '0.2.6'
 SUCATALOG_URL = 'https://swscan.apple.com/content/catalogs/others/index-11-10.15-10.14-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog'
 # 7-Zip MSI (15.14)
-SEVENZIP_URL = 'https://www.7-zip.org/a/7z2201-x64.msi'
+SEVENZIP_URL = 'https://github.com/ip7z/7zip/releases/download/21.07/7z2107-x64.exe'
 
 def status(msg):
     print "%s\n" % msg

--- a/brigadier.ps1
+++ b/brigadier.ps1
@@ -50,7 +50,7 @@ Param(
     
     # URL to download 7-Zip from, if not installed
     [Alias('SEVENZIP_URL')]
-    [string]$SevenZipURL = 'https://www.7-zip.org/a/7z1900-x64.exe'
+    [string]$SevenZipURL = 'https://github.com/ip7z/7zip/releases/download/21.07/7z2107-x64.exe'
 )
 
 # Disable Invoke-WebRequest progress bar to speed up download due to bug


### PR DESCRIPTION
This code replaces the old 7z download link with the GitHub version to try to fix the broken 7z version that is currently being installed in the original program.